### PR TITLE
feat(comments): self-delete UI, instant POST visibility, and SIWE recovery polish

### DIFF
--- a/src/components/Comments/CommentList.tsx
+++ b/src/components/Comments/CommentList.tsx
@@ -42,7 +42,7 @@ function shortenAddress(addr: string): string {
 export const CommentList: React.FC<CommentListProps> = ({ qciId }) => {
   const { comments, isLoading, isError, error, hasMore, isFetchingMore, fetchMore } = useComments(qciId);
   const { isEditor } = useIsEditor();
-  const { sessionToken } = useSiweSession();
+  const { sessionToken, address: viewerAddress } = useSiweSession();
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   // Infinite scroll: when the sentinel below the last row enters the viewport,
@@ -102,7 +102,8 @@ export const CommentList: React.FC<CommentListProps> = ({ qciId }) => {
           key={c.id}
           comment={c}
           qciId={qciId}
-          showModeration={isEditor}
+          isEditor={isEditor}
+          viewerAddress={viewerAddress}
           sessionToken={sessionToken}
         />
       ))}
@@ -120,18 +121,29 @@ export const CommentList: React.FC<CommentListProps> = ({ qciId }) => {
 interface CommentRowProps {
   comment: Comment;
   qciId: number;
-  showModeration: boolean;
+  isEditor: boolean;
+  viewerAddress?: string;
   sessionToken?: string;
 }
 
 const CommentRow: React.FC<CommentRowProps> = ({
   comment,
   qciId,
-  showModeration,
+  isEditor,
+  viewerAddress,
   sessionToken,
 }) => {
   const display = comment.ensName ?? shortenAddress(comment.author);
   const timestamp = formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true });
+  const isHidden = Boolean(comment.hiddenAt);
+  const isOwner =
+    !!viewerAddress &&
+    !isHidden &&
+    viewerAddress.toLowerCase() === comment.author.toLowerCase();
+  // ModerationMenu picks its own mode internally; only render the wrapper
+  // when there's a meaningful action available, so non-editor non-owners
+  // see no trigger at all.
+  const showMenu = isEditor || isOwner;
 
   return (
     <div className="flex gap-3 border-b border-border/40 pb-6 last:border-0">
@@ -147,12 +159,15 @@ const CommentRow: React.FC<CommentRowProps> = ({
         <div className="flex items-baseline gap-2">
           <span className="font-medium text-foreground">{display}</span>
           <span className="text-xs text-muted-foreground">{timestamp}</span>
-          {showModeration && (
+          {showMenu && (
             <div className="ml-auto">
               <ModerationMenu
                 qciId={qciId}
                 commentId={comment.id}
-                isHidden={Boolean(comment.hiddenAt)}
+                commentAuthor={comment.author}
+                isHidden={isHidden}
+                viewerAddress={viewerAddress}
+                isEditor={isEditor}
                 sessionToken={sessionToken}
               />
             </div>

--- a/src/components/Comments/ModerationMenu.tsx
+++ b/src/components/Comments/ModerationMenu.tsx
@@ -32,42 +32,22 @@ interface ModerationMenuProps {
   isHidden: boolean;
   /** Lowercased current SIWE-session address, or undefined when no session. */
   viewerAddress?: string;
-  /** Editor takes precedence over owner mode when both are true. */
+  /** Whether the viewer holds EDITOR_ROLE on the registry. */
   isEditor: boolean;
   sessionToken?: string;
 }
 
-type MenuMode = 'editor' | 'owner' | 'none';
-
-function pickMode(args: {
-  isEditor: boolean;
-  viewerAddress?: string;
-  commentAuthor: string;
-  isHidden: boolean;
-}): MenuMode {
-  if (args.isEditor) return 'editor';
-  if (
-    args.viewerAddress &&
-    !args.isHidden &&
-    args.viewerAddress.toLowerCase() === args.commentAuthor.toLowerCase()
-  ) {
-    return 'owner';
-  }
-  return 'none';
-}
-
 /**
- * Per-row menu attached to each rendered comment. Two display modes:
+ * Per-row menu attached to each rendered comment. Renders applicable
+ * actions independently — an editor viewing their own visible comment
+ * sees BOTH "Hide" (editor action) and "Delete" (owner action), since
+ * they're distinct operations: Hide is reversible and audit-tagged with
+ * an editor reason; Delete is irreversible self-removal. Server enforces
+ * each action's authorization independently of these UI gates.
  *
- *   - editor: hide / restore (existing flow). Visible whenever the viewer
- *     has EDITOR_ROLE on the QCIRegistry. Server enforces hasRole() again,
- *     independent of this UI gate.
- *   - owner:  delete-own (new flow). Visible when the viewer is NOT an
- *     editor, IS the comment's author, and the comment is currently visible.
- *     Server enforces author == session.address again as a SQL predicate.
- *
- * Editor takes precedence — an editor reading their own comment uses the
- * hide flow, mirroring how every comment platform handles overlap.
+ *   Editor (hide/restore): renders when isEditor === true.
+ *   Owner  (delete):       renders when viewerAddress matches comment.author
+ *                          AND the comment is currently visible.
  */
 export const ModerationMenu: React.FC<ModerationMenuProps> = ({
   qciId,
@@ -86,7 +66,11 @@ export const ModerationMenu: React.FC<ModerationMenuProps> = ({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [reason, setReason] = useState('');
 
-  const mode = pickMode({ isEditor, viewerAddress, commentAuthor, isHidden });
+  const canDeleteOwn =
+    !!viewerAddress &&
+    !isHidden &&
+    viewerAddress.toLowerCase() === commentAuthor.toLowerCase();
+  const showMenu = isEditor || canDeleteOwn;
 
   const hideMutation = useMutation({
     mutationFn: async () => {
@@ -181,7 +165,7 @@ export const ModerationMenu: React.FC<ModerationMenuProps> = ({
     }
   };
 
-  if (mode === 'none') return null;
+  if (!showMenu) return null;
 
   return (
     <>
@@ -191,13 +175,13 @@ export const ModerationMenu: React.FC<ModerationMenuProps> = ({
             variant="ghost"
             size="icon"
             className="h-7 w-7 text-muted-foreground hover:text-foreground"
-            aria-label={mode === 'owner' ? 'Comment actions' : 'Moderation menu'}
+            aria-label="Comment actions"
           >
             <MoreHorizontal className="h-4 w-4" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          {mode === 'editor' && isHidden && (
+          {isEditor && isHidden && (
             <DropdownMenuItem
               onSelect={() => unhideMutation.mutate()}
               disabled={unhideMutation.isPending}
@@ -205,12 +189,12 @@ export const ModerationMenu: React.FC<ModerationMenuProps> = ({
               Restore comment
             </DropdownMenuItem>
           )}
-          {mode === 'editor' && !isHidden && (
+          {isEditor && !isHidden && (
             <DropdownMenuItem onSelect={() => setHideDialogOpen(true)}>
               Hide comment
             </DropdownMenuItem>
           )}
-          {mode === 'owner' && (
+          {canDeleteOwn && (
             <DropdownMenuItem
               onSelect={() => setDeleteDialogOpen(true)}
               disabled={isDeleting}

--- a/src/components/Comments/ModerationMenu.tsx
+++ b/src/components/Comments/ModerationMenu.tsx
@@ -3,6 +3,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { MoreHorizontal } from 'lucide-react';
 import { toast } from 'sonner';
 import { config } from '@/config/env';
+import { useComments } from '@/hooks/useComments';
+import { useSiweSession } from '@/hooks/useSiweSession';
 import { getMaiAPIClient } from '@/services/maiApiClient';
 import { Button } from '@/components/ui/button';
 import {
@@ -25,31 +27,66 @@ import { queryKeyPatterns, queryKeys } from '@/utils/queryKeys';
 interface ModerationMenuProps {
   qciId: number;
   commentId: number;
+  /** Lowercased 0x-prefixed comment author address. */
+  commentAuthor: string;
   isHidden: boolean;
+  /** Lowercased current SIWE-session address, or undefined when no session. */
+  viewerAddress?: string;
+  /** Editor takes precedence over owner mode when both are true. */
+  isEditor: boolean;
   sessionToken?: string;
 }
 
+type MenuMode = 'editor' | 'owner' | 'none';
+
+function pickMode(args: {
+  isEditor: boolean;
+  viewerAddress?: string;
+  commentAuthor: string;
+  isHidden: boolean;
+}): MenuMode {
+  if (args.isEditor) return 'editor';
+  if (
+    args.viewerAddress &&
+    !args.isHidden &&
+    args.viewerAddress.toLowerCase() === args.commentAuthor.toLowerCase()
+  ) {
+    return 'owner';
+  }
+  return 'none';
+}
+
 /**
- * Editor-only menu attached to each rendered comment. The visual gate (only
- * rendered when useIsEditor() returns true) is polish; the API enforces
- * authorization independently — the moderation routes call hasRole()
- * server-side before applying any change.
+ * Per-row menu attached to each rendered comment. Two display modes:
  *
- * Hide flow uses optimistic UI: the row is removed from the list cache as
- * soon as the user confirms, then we invalidate after the mutation resolves
- * to pick up the API's authoritative state. On error we re-invalidate so
- * the row reappears.
+ *   - editor: hide / restore (existing flow). Visible whenever the viewer
+ *     has EDITOR_ROLE on the QCIRegistry. Server enforces hasRole() again,
+ *     independent of this UI gate.
+ *   - owner:  delete-own (new flow). Visible when the viewer is NOT an
+ *     editor, IS the comment's author, and the comment is currently visible.
+ *     Server enforces author == session.address again as a SQL predicate.
+ *
+ * Editor takes precedence — an editor reading their own comment uses the
+ * hide flow, mirroring how every comment platform handles overlap.
  */
 export const ModerationMenu: React.FC<ModerationMenuProps> = ({
   qciId,
   commentId,
+  commentAuthor,
   isHidden,
+  viewerAddress,
+  isEditor,
   sessionToken,
 }) => {
   const queryClient = useQueryClient();
   const client = getMaiAPIClient(config.maiApiUrl);
+  const { deleteComment, isDeleting } = useComments(qciId);
+  const { clearOn401 } = useSiweSession();
   const [hideDialogOpen, setHideDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [reason, setReason] = useState('');
+
+  const mode = pickMode({ isEditor, viewerAddress, commentAuthor, isHidden });
 
   const hideMutation = useMutation({
     mutationFn: async () => {
@@ -117,6 +154,35 @@ export const ModerationMenu: React.FC<ModerationMenuProps> = ({
     },
   });
 
+  const handleConfirmDelete = async () => {
+    setDeleteDialogOpen(false);
+    const result = await deleteComment({ commentId, sessionToken });
+    if (result.ok) {
+      toast.success('Comment deleted');
+      return;
+    }
+    switch (result.status) {
+      case 401:
+        clearOn401();
+        toast.error('Your session expired. Please sign in again.');
+        break;
+      case 403:
+        // Defensive — UI should never expose Delete on a non-owned row.
+        toast.error('You can only delete your own comments.');
+        break;
+      case 404:
+        toast.error('Comment not found.');
+        break;
+      case 409:
+        toast.error('This comment is already hidden.');
+        break;
+      default:
+        toast.error(`Couldn't delete: ${result.error}`);
+    }
+  };
+
+  if (mode === 'none') return null;
+
   return (
     <>
       <DropdownMenu>
@@ -125,22 +191,32 @@ export const ModerationMenu: React.FC<ModerationMenuProps> = ({
             variant="ghost"
             size="icon"
             className="h-7 w-7 text-muted-foreground hover:text-foreground"
-            aria-label="Moderation menu"
+            aria-label={mode === 'owner' ? 'Comment actions' : 'Moderation menu'}
           >
             <MoreHorizontal className="h-4 w-4" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          {isHidden ? (
+          {mode === 'editor' && isHidden && (
             <DropdownMenuItem
               onSelect={() => unhideMutation.mutate()}
               disabled={unhideMutation.isPending}
             >
               Restore comment
             </DropdownMenuItem>
-          ) : (
+          )}
+          {mode === 'editor' && !isHidden && (
             <DropdownMenuItem onSelect={() => setHideDialogOpen(true)}>
               Hide comment
+            </DropdownMenuItem>
+          )}
+          {mode === 'owner' && (
+            <DropdownMenuItem
+              onSelect={() => setDeleteDialogOpen(true)}
+              disabled={isDeleting}
+              className="text-destructive focus:text-destructive"
+            >
+              Delete
             </DropdownMenuItem>
           )}
         </DropdownMenuContent>
@@ -183,6 +259,29 @@ export const ModerationMenu: React.FC<ModerationMenuProps> = ({
               disabled={hideMutation.isPending}
             >
               {hideMutation.isPending ? 'Hiding...' : 'Hide'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete this comment?</DialogTitle>
+            <DialogDescription>
+              This can't be undone. The comment is removed from the public view immediately.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleConfirmDelete}
+              disabled={isDeleting}
+            >
+              {isDeleting ? 'Deleting...' : 'Delete'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/Comments/SiweLoginButton.tsx
+++ b/src/components/Comments/SiweLoginButton.tsx
@@ -28,10 +28,15 @@ const chainLabel = (chainId: number): string =>
  *   wallet, no session  → "Sign in to comment" button → useSiweSession.signIn()
  *   wallet + session    → renders nothing (composer takes over).
  *
- * Sign-in errors map to silent / toast surfaces:
- *   user_rejected → silent (the user just cancelled the wallet popup)
- *   verify_failed → toast (the API rejected the SIWE message)
- *   unknown       → toast (transport error, etc.)
+ * Sign-in errors map to toast surfaces:
+ *   user_rejected → info toast naming the recovery affordance. Also covers
+ *                   the silent-dismiss case where the wallet popup is
+ *                   closed without an explicit reject; useSiweSession's
+ *                   timeout synthesises a user_rejected reason so the UI
+ *                   never strands on "Signing in…".
+ *   wrong_chain   → error toast naming the target chain.
+ *   verify_failed → error toast (the API rejected the SIWE message).
+ *   unknown       → error toast (transport error, etc.).
  */
 export const SiweLoginButton: React.FC = () => {
   const { address, isConnected } = useAccount();
@@ -55,7 +60,12 @@ export const SiweLoginButton: React.FC = () => {
     <Button
       onClick={async () => {
         const result = await signIn();
-        if (result.ok || result.reason === 'user_rejected') return;
+        if (result.ok) return;
+
+        if (result.reason === 'user_rejected') {
+          toast.info("Sign-in cancelled. Click 'Sign in to comment' to try again.");
+          return;
+        }
 
         if (result.reason === 'wrong_chain') {
           const targetChainId = pickSiweChainId(walletChainId, safeDeployments);

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -2,12 +2,14 @@ import {
   useInfiniteQuery,
   useMutation,
   useQueryClient,
+  type InfiniteData,
 } from '@tanstack/react-query';
 import { config } from '../config/env';
 import { getMaiAPIClient } from '../services/maiApiClient';
 import type {
   Comment,
   CommentListResponse,
+  DeleteOwnCommentResponse,
   PostCommentResponse,
 } from '../types/comments';
 import { queryKeys } from '../utils/queryKeys';
@@ -21,6 +23,11 @@ interface PostCommentArgs {
    * Optional bearer token. When omitted, the same-origin HttpOnly cookie
    * authenticates the request (cross-origin deployments must pass the token).
    */
+  sessionToken?: string;
+}
+
+interface DeleteCommentArgs {
+  commentId: number;
   sessionToken?: string;
 }
 
@@ -43,6 +50,15 @@ export interface UseCommentsResult {
    */
   postComment: (args: PostCommentArgs) => Promise<PostCommentResponse>;
   isPosting: boolean;
+
+  /**
+   * Self-delete a comment authored by the current session. Performs an
+   * optimistic cache removal and rolls back on failure (server-side error
+   * or network failure). Returns the discriminated API result so callers
+   * can render specific error toasts (401/403/etc.).
+   */
+  deleteComment: (args: DeleteCommentArgs) => Promise<DeleteOwnCommentResponse>;
+  isDeleting: boolean;
 }
 
 /**
@@ -75,15 +91,96 @@ export function useComments(qciId: number): UseCommentsResult {
     mutationFn: async ({ body, sessionToken }) =>
       client.postQipComment({ qciId, body, sessionToken }),
     onSuccess: (result) => {
-      // Only invalidate on a real insert. A 403 / 401 / 413 / etc. is a
-      // structured rejection — there's no new row to fold into the list.
-      if (result.ok) {
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.qipComments(qciId),
+      // Only mutate the cache on a real insert. A 403 / 401 / 413 / etc. is
+      // a structured rejection — there's no new row to fold in.
+      if (!result.ok) return;
+      // Direct cache merge using the row the server already returned: skips
+      // the invalidate→refetch round trip so the comment appears in the
+      // list synchronously when the toast fires. The next background fetch
+      // will dedupe by `id`.
+      queryClient.setQueryData<InfiniteData<CommentListResponse>>(
+        queryKeys.qipComments(qciId),
+        (oldData) => {
+          if (!oldData || oldData.pages.length === 0) return oldData;
+          const [firstPage, ...restPages] = oldData.pages;
+          return {
+            ...oldData,
+            pages: [
+              { ...firstPage, comments: [result.comment, ...firstPage.comments] },
+              ...restPages,
+            ],
+          };
+        },
+      );
+    },
+  });
+
+  // Optimistic delete: remove the row from cache before the request lands so
+  // the UI feels instant. On any rejection (server 4xx/5xx, network error)
+  // we restore the snapshot taken in `onMutate` so the comment reappears.
+  type DeleteContext = {
+    previous: InfiniteData<CommentListResponse> | undefined;
+  };
+
+  const deleteMutation = useMutation<
+    DeleteOwnCommentResponse,
+    Error,
+    DeleteCommentArgs,
+    DeleteContext
+  >({
+    mutationFn: async ({ commentId, sessionToken }) => {
+      const result = await client.deleteOwnQipComment({ commentId, sessionToken });
+      // A structured `{ ok: false, ... }` rejection must trigger rollback —
+      // useMutation only treats thrown errors as failures, so coerce here.
+      if (!result.ok) {
+        const err = new Error(result.error) as Error & {
+          deleteResult: DeleteOwnCommentResponse;
+        };
+        err.deleteResult = result;
+        throw err;
+      }
+      return result;
+    },
+    onMutate: ({ commentId }) => {
+      const key = queryKeys.qipComments(qciId);
+      const previous =
+        queryClient.getQueryData<InfiniteData<CommentListResponse>>(key);
+      if (previous) {
+        queryClient.setQueryData<InfiniteData<CommentListResponse>>(key, {
+          ...previous,
+          pages: previous.pages.map((page) => ({
+            ...page,
+            comments: page.comments.filter((c) => c.id !== commentId),
+          })),
         });
+      }
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          queryKeys.qipComments(qciId),
+          context.previous,
+        );
       }
     },
   });
+
+  // Wrapper preserves the discriminated-union return shape callers expect.
+  // useMutation throws on `{ ok: false }` so we re-derive the structured
+  // result from the thrown error's payload (or rethrow on network errors).
+  const deleteComment = async (
+    args: DeleteCommentArgs,
+  ): Promise<DeleteOwnCommentResponse> => {
+    try {
+      return await deleteMutation.mutateAsync(args);
+    } catch (err) {
+      const carried = (err as { deleteResult?: DeleteOwnCommentResponse })
+        .deleteResult;
+      if (carried) return carried;
+      throw err;
+    }
+  };
 
   return {
     comments: query.data?.pages.flatMap((p) => p.comments) ?? [],
@@ -100,5 +197,7 @@ export function useComments(qciId: number): UseCommentsResult {
     },
     postComment: mutation.mutateAsync,
     isPosting: mutation.isPending,
+    deleteComment,
+    isDeleting: deleteMutation.isPending,
   };
 }

--- a/src/hooks/useSiweSession.ts
+++ b/src/hooks/useSiweSession.ts
@@ -44,6 +44,14 @@ export interface UseSiweSessionResult {
 
 const STATEMENT = 'Sign in to leave a comment on this QIP.';
 const NONCE_TTL_SECONDS = 10 * 60;
+// Generous upper bound for how long a wallet may take to surface its
+// signature prompt. Some Safe-import flows (notably Rabby's) leave
+// signMessageAsync pending if the user dismisses the popup silently
+// rather than clicking reject. The timeout treats that case as a
+// cancellation so the sign-in button re-enables instead of staying stuck
+// on "Signing in…". 90s is comfortably longer than any realistic wallet
+// UX and short enough to recover before the user gives up on the page.
+const SIGN_MESSAGE_TIMEOUT_MS = 90_000;
 
 /* ─────────────────────────────────────────────────────────
    Shared session state (module-scoped singleton)
@@ -271,11 +279,29 @@ export function useSiweSession(): UseSiweSessionResult {
       const messageBody = message.prepareMessage();
 
       // 3. Sign with the connected wallet. User rejection lands in the catch.
+      // The Promise.race timeout guards against wallets that leave
+      // signMessageAsync pending forever when the user silently dismisses the
+      // popup — a finite cap is the only reliable way to recover the UI.
       let signature: string;
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
       try {
-        signature = await signMessageAsync({ message: messageBody });
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(
+            () => reject(new Error('sign_timeout')),
+            SIGN_MESSAGE_TIMEOUT_MS,
+          );
+        });
+        signature = await Promise.race([
+          signMessageAsync({ message: messageBody }),
+          timeoutPromise,
+        ]);
       } catch (err) {
         setSessionState({ ...sessionState, status: 'idle' });
+        if (err instanceof Error && err.message === 'sign_timeout') {
+          // Treat silent dismissal as a cancellation — same downstream
+          // shape as an explicit reject in the wallet.
+          return { ok: false, reason: 'user_rejected' };
+        }
         if (
           err instanceof Error &&
           /reject|denied|cancel/i.test(err.message)
@@ -283,6 +309,8 @@ export function useSiweSession(): UseSiweSessionResult {
           return { ok: false, reason: 'user_rejected' };
         }
         return { ok: false, reason: 'unknown' };
+      } finally {
+        if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
       }
 
       // 4. Verify with the API and capture the bearer token.
@@ -312,6 +340,13 @@ export function useSiweSession(): UseSiweSessionResult {
       console.error('[useSiweSession] sign-in failed before verify:', err);
       setSessionState({ ...sessionState, status: 'idle' });
       return { ok: false, reason: 'unknown' };
+    } finally {
+      // Belt-and-suspenders: every non-success path above is supposed to
+      // reset to 'idle', but if a future change ever forgets one this
+      // guarantees the UI never strands in 'signing'.
+      if (sessionState.status === 'signing') {
+        setSessionState({ ...sessionState, status: 'idle' });
+      }
     }
   }, [isConnected, walletAddress, walletChainId, safeDeployments, signMessageAsync, switchChainAsync]);
 

--- a/src/hooks/useSiweSession.ts
+++ b/src/hooks/useSiweSession.ts
@@ -23,7 +23,10 @@ export interface UseSiweSessionResult {
   status: SiweSessionStatus;
   /** Lowercased authenticated address, present iff status === 'authenticated'. */
   address?: string;
-  /** In-memory bearer token. Never persisted to localStorage / sessionStorage. */
+  /**
+   * Bearer token. Persisted in `localStorage` under a versioned key; cleared
+   * on sign-out, 401, wallet switch, expiry, or actively-disconnected state.
+   */
   sessionToken?: string;
   isPending: boolean;
 
@@ -79,8 +82,93 @@ function subscribeSessionState(listener: () => void): () => void {
   return () => subscribers.delete(listener);
 }
 
+/* ─────────────────────────────────────────────────────────
+   Persisted session (localStorage)
+   ─────────────────────────────────────────────────────────
+   The bearer token returned by /v2/auth/qip-comments/verify also lives in
+   an HttpOnly Set-Cookie, but mai-api and the QIPs frontend are cross-origin
+   in dev (mai-api.qidao.localhost ↔ qips.qidao.localhost) and prod, and the
+   cookie is SameSite=Strict in prod — i.e. the cookie is never sent on
+   cross-origin requests. The verify response carries the bearer in JSON for
+   exactly this case. We persist {token, address, expiresAt} so a page reload
+   doesn't strand the user back on the sign-in button. Threat model: the
+   token authorizes posting comments under the connected address; the VP
+   gate stays server-side. Bumping the key version (v1 → v2) invalidates
+   stale entries instantly if the persisted shape ever changes.
+*/
+const PERSISTED_SESSION_KEY = 'qip-comments:siwe-session:v1';
+
+interface PersistedSessionEntry {
+  token: string;
+  address: string;
+  expiresAt: string;
+}
+
+function clearPersistedSession(): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.removeItem(PERSISTED_SESSION_KEY);
+  } catch {
+    // Storage disabled or quota error — non-fatal.
+  }
+}
+
+function readPersistedSession(): SessionState | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    const raw = localStorage.getItem(PERSISTED_SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<PersistedSessionEntry>;
+    if (
+      typeof parsed.token !== 'string' ||
+      typeof parsed.address !== 'string' ||
+      typeof parsed.expiresAt !== 'string'
+    ) {
+      clearPersistedSession();
+      return null;
+    }
+    if (new Date(parsed.expiresAt).getTime() <= Date.now()) {
+      clearPersistedSession();
+      return null;
+    }
+    return {
+      status: 'authenticated',
+      sessionToken: parsed.token,
+      address: parsed.address.toLowerCase(),
+    };
+  } catch {
+    clearPersistedSession();
+    return null;
+  }
+}
+
+function writePersistedSession(token: string, address: string, expiresAt: string): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    const entry: PersistedSessionEntry = {
+      token,
+      address: address.toLowerCase(),
+      expiresAt,
+    };
+    localStorage.setItem(PERSISTED_SESSION_KEY, JSON.stringify(entry));
+  } catch {
+    // Storage disabled or quota error — non-fatal; in-memory session still works.
+  }
+}
+
+// Hydrate the singleton from persisted state once at module init, before any
+// component mounts. Reading at module scope avoids a first-render flicker
+// where the sign-in button would briefly render before a useEffect could
+// pull the persisted entry.
+{
+  const persisted = readPersistedSession();
+  if (persisted !== null) {
+    sessionState = persisted;
+  }
+}
+
 export function useSiweSession(): UseSiweSessionResult {
-  const { address: walletAddress, isConnected } = useAccount();
+  const { address: walletAddress, isConnected, status: accountStatus } = useAccount();
   // EIP-4361 requires a chainId in the SIWE message. For EOAs it is
   // informational; for smart-account signers (Safe and other EIP-1271
   // wallets) it tells the verifier which chain's RPC to query for
@@ -110,10 +198,14 @@ export function useSiweSession(): UseSiweSessionResult {
 
   // If the user disconnects their wallet (or switches accounts), drop the
   // local session — it's no longer attributable to whoever's currently
-  // controlling the page.
+  // controlling the page. Use `status === 'disconnected'` rather than
+  // `!isConnected`: on page reload wagmi briefly reports disconnected
+  // while it reconnects ('connecting' / 'reconnecting' transient states),
+  // and dropping the session there would defeat the persistence layer.
   useEffect(() => {
-    if (!isConnected) {
+    if (accountStatus === 'disconnected') {
       if (sessionState.sessionToken !== undefined || sessionState.status !== 'idle') {
+        clearPersistedSession();
         setSessionState({ status: 'idle', sessionToken: undefined, address: undefined });
       }
       return;
@@ -123,9 +215,10 @@ export function useSiweSession(): UseSiweSessionResult {
       walletAddress &&
       sessionState.address.toLowerCase() !== walletAddress.toLowerCase()
     ) {
+      clearPersistedSession();
       setSessionState({ status: 'idle', sessionToken: undefined, address: undefined });
     }
-  }, [isConnected, walletAddress]);
+  }, [accountStatus, walletAddress]);
 
   const signIn = useCallback(async (): Promise<
     { ok: true } | { ok: false; reason: SiweSignInError }
@@ -207,6 +300,7 @@ export function useSiweSession(): UseSiweSessionResult {
       }
 
       const lowercased = verifyResp.address.toLowerCase();
+      writePersistedSession(verifyResp.token, lowercased, verifyResp.expiresAt);
       setSessionState({
         status: 'authenticated',
         sessionToken: verifyResp.token,
@@ -222,6 +316,7 @@ export function useSiweSession(): UseSiweSessionResult {
   }, [isConnected, walletAddress, walletChainId, safeDeployments, signMessageAsync, switchChainAsync]);
 
   const signOut = useCallback(() => {
+    clearPersistedSession();
     setSessionState({ status: 'idle', sessionToken: undefined, address: undefined });
   }, []);
 
@@ -229,6 +324,7 @@ export function useSiweSession(): UseSiweSessionResult {
     // Same effect as signOut, but the name flags the intent at the call
     // site so it's clear we're reacting to a server-side session expiry,
     // not a user action.
+    clearPersistedSession();
     setSessionState({ status: 'idle', sessionToken: undefined, address: undefined });
   }, []);
 

--- a/src/services/maiApiClient.ts
+++ b/src/services/maiApiClient.ts
@@ -7,6 +7,8 @@
 import { QCIStatus } from './qciClient';
 import type {
   CommentListResponse,
+  DeleteOwnCommentRequest,
+  DeleteOwnCommentResponse,
   ListCommentsOptions,
   ModerationRequest,
   ModerationResponse,
@@ -373,6 +375,28 @@ export class MaiAPIClient {
         { version: string; threshold: number; ownerCount: number }
       >;
     };
+  }
+
+  /**
+   * Self-delete: the authenticated wallet removes its own comment.
+   * Reuses the moderation response shape — the 403 case carries
+   * `error: 'not_owner'` when the session address doesn't match the
+   * comment's author.
+   */
+  async deleteOwnQipComment(
+    req: DeleteOwnCommentRequest,
+  ): Promise<DeleteOwnCommentResponse> {
+    return this.commentsResultRequest<DeleteOwnCommentResponse>(
+      'POST',
+      `/v2/comments/${req.commentId}/delete`,
+      {},
+      req.sessionToken,
+      (_status, payload) => ({
+        ok: true,
+        commentId: (payload as { commentId: number }).commentId,
+        actionId: (payload as { actionId: number }).actionId,
+      }),
+    ) as Promise<DeleteOwnCommentResponse>;
   }
 
   /** Editor-only: unhide a previously hidden comment. */

--- a/src/types/comments.ts
+++ b/src/types/comments.ts
@@ -107,3 +107,27 @@ export interface ModerationRequest {
 export type ModerationResponse =
   | { ok: true; commentId: number; actionId: number }
   | { ok: false; status: 401 | 403 | 404 | 409 | 400 | 500; error: string };
+
+/* ─────────────────────────────────────────────────────────
+   Self-delete — POST /v2/comments/:id/delete
+   ───────────────────────────────────────────────────────── */
+
+/**
+ * Self-delete: an authenticated wallet removes its own comment.
+ *
+ * No `reason` field — the server forces `hiddenReason = 'self_deleted'`
+ * so a malicious client can't spoof an editor-style reason. Server-side
+ * ownership is enforced as a SQL predicate (the session-bound address must
+ * match `qipComments.author`); the 403 'not_owner' shape is for defense in
+ * depth, since the UI hides the trigger from non-authors.
+ */
+export interface DeleteOwnCommentRequest {
+  commentId: number;
+  sessionToken?: string;
+}
+
+/**
+ * Identical-shape to ModerationResponse. Reused rather than aliased so callers
+ * can pattern-match the 403 'not_owner' case against the same union members.
+ */
+export type DeleteOwnCommentResponse = ModerationResponse;


### PR DESCRIPTION
## Summary

Bundles the comment-feature follow-ups currently sitting on this branch:

- **Self-delete** for comment authors. New owner-mode option in the per-row menu; optimistic cache removal with rollback on failure.
- **Instant POST visibility.** Successful POST writes the returned comment directly into the React Query cache, so the new row appears at the top of the list synchronously when the toast fires (no refetch round-trip, no need to refresh the page).
- **SIWE recovery polish** (carried from prior work). Persists session to `localStorage` so reloads don't kill the composer, and recovers cleanly from popup-dismissal / silent-rejection sign-in failures.

## Self-delete details

- New per-row dropdown actions in `ModerationMenu`. Editor and owner actions render independently — an editor reading their own visible comment sees BOTH "Hide" (reversible, audit-tagged) and "Delete" (irreversible self-removal). Each has its own confirmation dialog.
- `useComments` exposes `deleteComment` + `isDeleting`. `onMutate` snapshots cache and filters the row out of every page; `onError` restores the snapshot. Discriminated-union return shape so callers can render specific toasts (401 → clearOn401, 403 'not_owner' defensive, 404, 409, generic).
- Talks to `POST /v2/comments/{id}/delete` (open in a separate API PR). No body — server forces `hiddenReason='self_deleted'`.

## Instant-POST details

- Replaces `queryClient.invalidateQueries` with `setQueryData` that prepends the server-returned comment to `pages[0].comments`. The POST already returns the row with ENS resolved, so we have everything we need without another fetch.
- Background refetches dedupe naturally by id; `staleTime: 30s` remains, so the merged row isn't immediately overwritten by a refetch the user didn't ask for.
- Empty-cache and multi-page paths handled — undefined oldData is left alone, only `pages[0]` is mutated.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean
- [x] Manual: post a comment → appears at top of list immediately (no refresh)
- [x] Manual: open menu on own visible comment → see "Delete" → confirm → row disappears optimistically
- [ ] Manual: editor on own comment → sees both "Hide" and "Delete"
- [ ] Manual: simulate API failure mid-delete → row reappears + error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)